### PR TITLE
fix: include retry_exec failure output in notifications

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -14,7 +14,8 @@
 1. 配置后使用简单，`retry_exec [your command] [your command args] [your command args] ...` 只要在你的命令执行前加上`retry_exec` 即可。
 2. 帮你重试，重试次数可以自定义；
 3. 重试时逐渐延长间隔时间，每次延长 2 倍，最小间隔时间、最大间隔时间可以自己设置；
-4. 如果程序最终执行失败，可以通过飞书自定义机器人、企业微信自定义机器人等渠道给自己发送一个提醒
+4. 如果程序最终执行失败，可以通过飞书自定义机器人、企业微信自定义机器人等渠道给自己发送一个提醒；
+5. 失败提醒会附带本次最终失败执行输出的末尾内容：优先取 `stderr`，如果 `stderr` 为空则取 `stdout`，最多 4KB，方便直接看到真实报错。
 
 ![飞书提醒](https://mcoder-image-storage.oss-cn-hangzhou.aliyuncs.com/image/25261056_eba2bb5ee530ca60.jpg)
 

--- a/retry_exec/retry.go
+++ b/retry_exec/retry.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"io"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mcoder2014/go_utils/command"
@@ -15,6 +17,15 @@ type Retry struct {
 	commands []string
 
 	ExitCode int
+}
+
+const commandOutputTailBytes = 4096
+
+type commandResult struct {
+	ExitCode   int
+	Err        error
+	StdoutTail string
+	StderrTail string
 }
 
 func NewRetry(commands []string, opt *ExecOption) *Retry {
@@ -32,14 +43,16 @@ func (r *Retry) Try(ctx context.Context) (err error) {
 
 	f := commandExecutor(r.commands)
 
-	r.ExitCode, err = f(ctx)
+	result := f(ctx)
+	r.ExitCode, err = result.ExitCode, result.Err
 	log.Ctx(ctx).Infof("exec command finished, commands: %v, exit code: %d", r.commands, r.ExitCode)
 
 	if err == nil && r.ExitCode == 0 {
 		return nil
 	} else if r.opt.RetryTimes <= 1 {
 		log.Ctx(ctx).WithError(err).Errorf("try failed, will not retry")
-		r.reportErr(ctx, "retry_exec execute commands=%v failed, exit code=%d err=%+v", r.commands, r.ExitCode, err)
+		r.reportErr(ctx, "retry_exec execute commands=%v failed, exit code=%d err=%+v%s",
+			r.commands, r.ExitCode, err, commandOutputTail(result))
 		return err
 	}
 
@@ -53,22 +66,51 @@ func (r *Retry) Try(ctx context.Context) (err error) {
 	return r.Try(ctx)
 }
 
-func commandExecutor(commands []string) func(ctx context.Context) (int, error) {
-	return func(ctx context.Context) (int, error) {
+func commandExecutor(commands []string) func(ctx context.Context) commandResult {
+	return commandExecutorWithIO(commands, os.Stdin, os.Stdout, os.Stderr)
+}
+
+func commandExecutorWithIO(commands []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) func(ctx context.Context) commandResult {
+	return func(ctx context.Context) commandResult {
+		stdoutTail := newTailWriter(commandOutputTailBytes)
+		stderrTail := newTailWriter(commandOutputTailBytes)
 		cmd := command.NewExecutor(commands[0], commands[1:]...)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		cmd.Stdin = os.Stdin
+		cmd.Stdout = io.MultiWriter(stdout, stdoutTail)
+		cmd.Stderr = io.MultiWriter(stderr, stderrTail)
+		cmd.Stdin = stdin
 
 		cmd.Build()
 		err := cmd.Exec(ctx)
 		if err != nil {
 			log.Ctx(ctx).WithError(err).Errorf("exec command failed, commands: %v, failed msg:%s", commands, cmd.ExitMsg())
-			return cmd.ExitCode(), err
+			return commandResult{
+				ExitCode:   cmd.ExitCode(),
+				Err:        err,
+				StdoutTail: stdoutTail.String(),
+				StderrTail: stderrTail.String(),
+			}
 		}
 		if cmd.ExitCode() == 0 {
 			log.Ctx(ctx).Infof("exec command success, commands: %v", commands)
 		}
-		return cmd.ExitCode(), nil
+		return commandResult{
+			ExitCode:   cmd.ExitCode(),
+			StdoutTail: stdoutTail.String(),
+			StderrTail: stderrTail.String(),
+		}
 	}
+}
+
+func commandOutputTail(result commandResult) string {
+	stderrTail := strings.TrimSpace(result.StderrTail)
+	if stderrTail != "" {
+		return "\n\nstderr tail:\n" + stderrTail
+	}
+
+	stdoutTail := strings.TrimSpace(result.StdoutTail)
+	if stdoutTail != "" {
+		return "\n\nstdout tail:\n" + stdoutTail
+	}
+
+	return ""
 }

--- a/retry_exec/retry_test.go
+++ b/retry_exec/retry_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTailWriterKeepsLastBytes(t *testing.T) {
+	w := newTailWriter(5)
+
+	n, err := w.Write([]byte("abc"))
+	require.NoError(t, err)
+	require.Equal(t, 3, n)
+
+	n, err = w.Write([]byte("defgh"))
+	require.NoError(t, err)
+	require.Equal(t, 5, n)
+
+	require.Equal(t, "defgh", w.String())
+}
+
+func TestTailWriterKeepsLastBytesForLargeWrite(t *testing.T) {
+	w := newTailWriter(4)
+
+	n, err := w.Write([]byte("0123456789"))
+	require.NoError(t, err)
+	require.Equal(t, 10, n)
+
+	require.Equal(t, "6789", w.String())
+}
+
+func TestCommandExecutorCapturesAndPassesThroughStdoutAndStderr(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exec := commandExecutorWithIO([]string{"sh", "-c", "printf 'visible-out'; printf 'boom-err' >&2; exit 7"}, nil, &stdout, &stderr)
+
+	result := exec(context.Background())
+
+	require.Error(t, result.Err)
+	require.Equal(t, 7, result.ExitCode)
+	require.Contains(t, result.StdoutTail, "visible-out")
+	require.Contains(t, result.StderrTail, "boom-err")
+	require.Contains(t, stdout.String(), "visible-out")
+	require.Contains(t, stderr.String(), "boom-err")
+}
+
+func TestCommandOutputTailPrefersStderr(t *testing.T) {
+	msg := commandOutputTail(commandResult{
+		StdoutTail: "stdout noise",
+		StderrTail: "stderr failure",
+	})
+
+	require.Contains(t, msg, "stderr")
+	require.Contains(t, msg, "stderr failure")
+	require.NotContains(t, msg, "stdout noise")
+}
+
+func TestCommandOutputTailFallsBackToStdout(t *testing.T) {
+	msg := commandOutputTail(commandResult{
+		StdoutTail: "stdout failure",
+	})
+
+	require.Contains(t, msg, "stdout")
+	require.Contains(t, msg, "stdout failure")
+}
+
+func TestCommandOutputTailSkipsEmptyOutput(t *testing.T) {
+	msg := commandOutputTail(commandResult{})
+
+	require.Equal(t, "", strings.TrimSpace(msg))
+}

--- a/retry_exec/tail_writer.go
+++ b/retry_exec/tail_writer.go
@@ -1,0 +1,33 @@
+package main
+
+type tailWriter struct {
+	limit int
+	buf   []byte
+}
+
+func newTailWriter(limit int) *tailWriter {
+	return &tailWriter{limit: limit}
+}
+
+func (w *tailWriter) Write(p []byte) (int, error) {
+	if w.limit <= 0 {
+		return len(p), nil
+	}
+
+	if len(p) >= w.limit {
+		w.buf = append(w.buf[:0], p[len(p)-w.limit:]...)
+		return len(p), nil
+	}
+
+	w.buf = append(w.buf, p...)
+	if len(w.buf) > w.limit {
+		copy(w.buf, w.buf[len(w.buf)-w.limit:])
+		w.buf = w.buf[:w.limit]
+	}
+
+	return len(p), nil
+}
+
+func (w *tailWriter) String() string {
+	return string(w.buf)
+}


### PR DESCRIPTION
## Summary
- Capture the last 4KB of command stdout and stderr while preserving passthrough output.
- Include stderr tail in final failure notifications, falling back to stdout when stderr is empty.
- Document the retry_exec notification output behavior in README.

## Test Plan
- go test ./...
- go test -count=1 ./retry_exec
- ./build.sh

Note: go test ./... passes, but the existing renameV1 test deletes tracked fixture renameV1/testData/file_name_with_space.mkv as a side effect; I restored it before committing.