### PR TITLE
feat: expand Codex Stop hook summary

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -79,10 +79,12 @@ Usage of ./renameV1:
 
 ## codex_hook_notify
 
-Codex 生命周期提醒工具。程序从 stdin 读取 Codex hook JSON，根据事件类型把提醒发送到飞书自定义机器人。第一版只处理：
+Codex 生命周期提醒工具。程序从 stdin 读取 Codex hook JSON，根据事件类型把提醒发送到飞书自定义机器人。当前处理：
 
-1. `Stop`：Codex 本轮完成或停止；
+1. `Stop`：Codex 本轮完成或停止。工具会优先读取本机 `CODEX_HOME/sessions`（默认 `~/.codex/sessions`）里的 transcript，推送最后一轮 Codex 用户可见输出；如果读不到 transcript，就回退到 hook 输入里的 `last_assistant_message`。
 2. `PermissionRequest`：Codex 等待用户批准执行命令或工具。
+
+`Stop` 内容较长时会拆成多条飞书 text 消息发送。推送内容按 Codex 输出原样发送，不做敏感信息脱敏；不要把真实 webhook 配到不可信群里。
 
 配置文件默认路径：`/etc/life_tools/codex_hook_notify.json`。示例配置在 `sample/life_tools/codex_hook_notify.json`。完整使用说明见 `docs/codex_hook_notify.md`。
 

--- a/README.MD
+++ b/README.MD
@@ -84,12 +84,15 @@ Codex 生命周期提醒工具。程序从 stdin 读取 Codex hook JSON，根据
 1. `Stop`：Codex 本轮完成或停止。工具会优先读取本机 `CODEX_HOME/sessions`（默认 `~/.codex/sessions`）里的 transcript，推送最后一轮 Codex 用户可见输出；如果读不到 transcript，就回退到 hook 输入里的 `last_assistant_message`。
 2. `PermissionRequest`：Codex 等待用户批准执行命令或工具。
 
+所有通知都会带 `Machine:` 字段。配置文件顶层 `machine_name` 非空时优先使用它；未配置或为空时使用操作系统 hostname；仍取不到时显示 `unknown`。
+
 `Stop` 内容较长时会拆成多条飞书 text 消息发送。推送内容按 Codex 输出原样发送，不做敏感信息脱敏；不要把真实 webhook 配到不可信群里。
 
 配置文件默认路径：`/etc/life_tools/codex_hook_notify.json`。示例配置在 `sample/life_tools/codex_hook_notify.json`。完整使用说明见 `docs/codex_hook_notify.md`。
 
 ```json
 {
+  "machine_name": "home-nas",
   "routes": [
     {
       "events": ["Stop"],

--- a/codex_hook_notify/config.go
+++ b/codex_hook_notify/config.go
@@ -1,12 +1,19 @@
 package main
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
 
 const DefaultConfigPath = "/etc/life_tools/codex_hook_notify.json"
 
 type Config struct {
-	Routes []Route `json:"routes"`
+	MachineName string  `json:"machine_name"`
+	Routes      []Route `json:"routes"`
 }
+
+type HostnameFunc func() (string, error)
 
 type Route struct {
 	Events                []string `json:"events"`
@@ -43,4 +50,22 @@ func contains(values []string, target string) bool {
 		}
 	}
 	return false
+}
+
+func ResolveMachineName(config Config, hostname HostnameFunc) string {
+	if name := strings.TrimSpace(config.MachineName); name != "" {
+		return name
+	}
+	if hostname == nil {
+		hostname = os.Hostname
+	}
+	name, err := hostname()
+	if err != nil {
+		return "unknown"
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "unknown"
+	}
+	return name
 }

--- a/codex_hook_notify/config_test.go
+++ b/codex_hook_notify/config_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,4 +47,41 @@ func TestMatchingURLsSkipsEmptyRoutes(t *testing.T) {
 	}
 
 	require.Equal(t, []string{"https://example.com/stop"}, config.MatchingURLs("Stop"))
+}
+
+func TestLoadConfigReadsMachineName(t *testing.T) {
+	config, err := LoadConfig([]byte(`{
+		"machine_name": "home-nas",
+		"routes": [
+			{"events": ["Stop"], "feishu_custom_robot_urls": ["https://example.com/stop"]}
+		]
+	}`))
+
+	require.NoError(t, err)
+	require.Equal(t, "home-nas", config.MachineName)
+	require.Equal(t, []string{"https://example.com/stop"}, config.MatchingURLs("Stop"))
+}
+
+func TestResolveMachineNameUsesConfigBeforeOS(t *testing.T) {
+	name := ResolveMachineName(Config{MachineName: "  custom-box  "}, func() (string, error) {
+		return "os-host", nil
+	})
+
+	require.Equal(t, "custom-box", name)
+}
+
+func TestResolveMachineNameFallsBackToOS(t *testing.T) {
+	name := ResolveMachineName(Config{}, func() (string, error) {
+		return "os-host", nil
+	})
+
+	require.Equal(t, "os-host", name)
+}
+
+func TestResolveMachineNameFallsBackToUnknown(t *testing.T) {
+	name := ResolveMachineName(Config{}, func() (string, error) {
+		return "", assert.AnError
+	})
+
+	require.Equal(t, "unknown", name)
 }

--- a/codex_hook_notify/event.go
+++ b/codex_hook_notify/event.go
@@ -47,20 +47,24 @@ func BuildMessage(event HookEvent) string {
 }
 
 func BuildMessages(event HookEvent) []string {
+	return BuildMessagesWithMachine(event, "")
+}
+
+func BuildMessagesWithMachine(event HookEvent, machineName string) []string {
 	content := summary(event)
-	parts := splitText(content, messageContentLimit(event))
+	parts := splitText(content, messageContentLimit(event, machineName))
 	if len(parts) == 0 {
 		parts = []string{"No summary available."}
 	}
 
 	messages := make([]string, 0, len(parts))
 	for i, part := range parts {
-		messages = append(messages, formatMessage(event, part, i+1, len(parts)))
+		messages = append(messages, formatMessage(event, machineName, part, i+1, len(parts)))
 	}
 	return messages
 }
 
-func formatMessage(event HookEvent, content string, part int, total int) string {
+func formatMessage(event HookEvent, machineName string, content string, part int, total int) string {
 	var buf bytes.Buffer
 	title := "Codex Hook Reminder"
 	if total > 1 {
@@ -69,6 +73,7 @@ func formatMessage(event HookEvent, content string, part int, total int) string 
 	writeLine(&buf, title)
 	writeLine(&buf, "")
 	writeLine(&buf, "Reason: "+valueOrUnknown(event.HookEventName))
+	writeOptionalLine(&buf, "Machine: ", machineName)
 	writeLine(&buf, "Session: "+valueOrUnknown(event.SessionID))
 	writeOptionalLine(&buf, "Turn: ", event.TurnID)
 	writeOptionalLine(&buf, "CWD: ", event.CWD)
@@ -214,8 +219,8 @@ func writeLine(buf *bytes.Buffer, line string) {
 	buf.WriteByte('\n')
 }
 
-func messageContentLimit(event HookEvent) int {
-	header := formatMessage(event, "", 999, 999)
+func messageContentLimit(event HookEvent, machineName string) int {
+	header := formatMessage(event, machineName, "", 999, 999)
 	limit := maxMessageBytes - len(header)
 	if limit < 1000 {
 		return 1000

--- a/codex_hook_notify/event.go
+++ b/codex_hook_notify/event.go
@@ -4,10 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 )
 
-const maxSummaryLen = 900
+const maxPermissionSummaryLen = 900
+const maxMessageBytes = 3600
 
 type HookEvent struct {
 	HookEventName        string          `json:"hook_event_name"`
@@ -40,8 +43,30 @@ func ParseHookEvent(content []byte) (HookEvent, error) {
 }
 
 func BuildMessage(event HookEvent) string {
+	return BuildMessages(event)[0]
+}
+
+func BuildMessages(event HookEvent) []string {
+	content := summary(event)
+	parts := splitText(content, messageContentLimit(event))
+	if len(parts) == 0 {
+		parts = []string{"No summary available."}
+	}
+
+	messages := make([]string, 0, len(parts))
+	for i, part := range parts {
+		messages = append(messages, formatMessage(event, part, i+1, len(parts)))
+	}
+	return messages
+}
+
+func formatMessage(event HookEvent, content string, part int, total int) string {
 	var buf bytes.Buffer
-	writeLine(&buf, "Codex Hook Reminder")
+	title := "Codex Hook Reminder"
+	if total > 1 {
+		title = fmt.Sprintf("%s [%d/%d]", title, part, total)
+	}
+	writeLine(&buf, title)
 	writeLine(&buf, "")
 	writeLine(&buf, "Reason: "+valueOrUnknown(event.HookEventName))
 	writeLine(&buf, "Session: "+valueOrUnknown(event.SessionID))
@@ -50,18 +75,42 @@ func BuildMessage(event HookEvent) string {
 	writeOptionalLine(&buf, "Model: ", event.Model)
 	writeOptionalLine(&buf, "Tool: ", event.ToolName)
 	writeLine(&buf, "Summary:")
-	writeLine(&buf, summary(event))
+	writeLine(&buf, content)
 	return buf.String()
 }
 
 func summary(event HookEvent) string {
 	if event.HookEventName == "PermissionRequest" {
-		return truncate(permissionSummary(event), maxSummaryLen)
+		return truncate(permissionSummary(event), maxPermissionSummaryLen)
+	}
+	if event.HookEventName == "Stop" {
+		return stopSummary(event, codexHome())
 	}
 	if event.LastAssistantMessage != "" {
-		return truncate(event.LastAssistantMessage, maxSummaryLen)
+		return truncate(event.LastAssistantMessage, maxPermissionSummaryLen)
 	}
 	return "No summary available."
+}
+
+func stopSummary(event HookEvent, codexHome string) string {
+	if text := transcriptSummary(event, codexHome); text != "" {
+		return text
+	}
+	if event.LastAssistantMessage != "" {
+		return strings.TrimSpace(event.LastAssistantMessage)
+	}
+	return "No summary available."
+}
+
+func codexHome() string {
+	if value := os.Getenv("CODEX_HOME"); value != "" {
+		return value
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".codex")
 }
 
 func permissionSummary(event HookEvent) string {
@@ -163,4 +212,60 @@ func writeOptionalLine(buf *bytes.Buffer, prefix string, value string) {
 func writeLine(buf *bytes.Buffer, line string) {
 	buf.WriteString(line)
 	buf.WriteByte('\n')
+}
+
+func messageContentLimit(event HookEvent) int {
+	header := formatMessage(event, "", 999, 999)
+	limit := maxMessageBytes - len(header)
+	if limit < 1000 {
+		return 1000
+	}
+	return limit
+}
+
+func splitText(value string, maxBytes int) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	if len(value) <= maxBytes {
+		return []string{value}
+	}
+
+	var parts []string
+	for len(value) > 0 {
+		if len(value) <= maxBytes {
+			parts = append(parts, value)
+			break
+		}
+		cut := splitIndex(value, maxBytes)
+		part := strings.TrimSpace(value[:cut])
+		if part != "" {
+			parts = append(parts, part)
+		}
+		value = strings.TrimSpace(value[cut:])
+	}
+	return parts
+}
+
+func splitIndex(value string, maxBytes int) int {
+	lastNewline := -1
+	end := 0
+	for i, r := range value {
+		next := i + len(string(r))
+		if next > maxBytes {
+			break
+		}
+		end = next
+		if r == '\n' {
+			lastNewline = next
+		}
+	}
+	if lastNewline > 0 {
+		return lastNewline
+	}
+	if end > 0 {
+		return end
+	}
+	return maxBytes
 }

--- a/codex_hook_notify/event_test.go
+++ b/codex_hook_notify/event_test.go
@@ -17,14 +17,16 @@ func TestBuildMessageForStop(t *testing.T) {
 		LastAssistantMessage: strings.Repeat("完成了一个很长的回答", 80),
 	}
 
-	msg := BuildMessage(event)
+	msgs := BuildMessages(event)
+	require.Len(t, msgs, 1)
+	msg := msgs[0]
 
 	require.Contains(t, msg, "Reason: Stop")
 	require.Contains(t, msg, "Session: session-123")
 	require.Contains(t, msg, "CWD: /tmp/project")
 	require.Contains(t, msg, "Model: gpt-test")
-	require.LessOrEqual(t, len(msg), 1600)
 	require.Contains(t, msg, "Summary:")
+	require.NotContains(t, msg, "(truncated)")
 }
 
 func TestBuildMessageForPermissionRequest(t *testing.T) {
@@ -41,13 +43,44 @@ func TestBuildMessageForPermissionRequest(t *testing.T) {
 	event, err := ParseHookEvent(raw)
 	require.NoError(t, err)
 
-	msg := BuildMessage(event)
+	msgs := BuildMessages(event)
+	require.Len(t, msgs, 1)
+	msg := msgs[0]
 
 	require.Contains(t, msg, "Reason: PermissionRequest")
 	require.Contains(t, msg, "Session: session-456")
 	require.Contains(t, msg, "Tool: functions.exec_command")
 	require.Contains(t, msg, "需要执行 git push")
 	require.Contains(t, msg, "git push origin")
+}
+
+func TestBuildMessagesSplitsLongStopSummary(t *testing.T) {
+	event := HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            "session-789",
+		TurnID:               "turn-789",
+		LastAssistantMessage: strings.Repeat("long output line\n", 600),
+	}
+
+	msgs := BuildMessages(event)
+
+	require.Greater(t, len(msgs), 1)
+	require.Contains(t, msgs[0], "Codex Hook Reminder [1/")
+	require.Contains(t, msgs[len(msgs)-1], "Codex Hook Reminder [")
+	require.NotContains(t, strings.Join(msgs, "\n"), "(truncated)")
+}
+
+func TestBuildMessagesKeepsNonStopEventsShort(t *testing.T) {
+	event := HookEvent{
+		HookEventName:        "PostToolUse",
+		SessionID:            "session-short",
+		LastAssistantMessage: strings.Repeat("long output line\\n", 600),
+	}
+
+	msgs := BuildMessages(event)
+
+	require.Len(t, msgs, 1)
+	require.Contains(t, msgs[0], "...(truncated)")
 }
 
 func TestSafeLogFileName(t *testing.T) {

--- a/codex_hook_notify/event_test.go
+++ b/codex_hook_notify/event_test.go
@@ -83,6 +83,49 @@ func TestBuildMessagesKeepsNonStopEventsShort(t *testing.T) {
 	require.Contains(t, msgs[0], "...(truncated)")
 }
 
+func TestBuildMessagesWithMachineIncludesMachineForStop(t *testing.T) {
+	event := HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            "session-machine",
+		LastAssistantMessage: "summary",
+	}
+
+	msgs := BuildMessagesWithMachine(event, "home-nas")
+
+	require.Len(t, msgs, 1)
+	require.Contains(t, msgs[0], "Reason: Stop")
+	require.Contains(t, msgs[0], "Machine: home-nas")
+	require.Contains(t, msgs[0], "Session: session-machine")
+}
+
+func TestBuildMessagesWithMachineIncludesMachineForPermissionRequest(t *testing.T) {
+	event := HookEvent{
+		HookEventName: "PermissionRequest",
+		SessionID:     "session-machine",
+	}
+
+	msgs := BuildMessagesWithMachine(event, "home-nas")
+
+	require.Len(t, msgs, 1)
+	require.Contains(t, msgs[0], "Reason: PermissionRequest")
+	require.Contains(t, msgs[0], "Machine: home-nas")
+}
+
+func TestBuildMessagesWithMachineIncludesMachineOnEveryPart(t *testing.T) {
+	event := HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            "session-parts-machine",
+		LastAssistantMessage: strings.Repeat("long output line\n", 600),
+	}
+
+	msgs := BuildMessagesWithMachine(event, "home-nas")
+
+	require.Greater(t, len(msgs), 1)
+	for _, msg := range msgs {
+		require.Contains(t, msg, "Machine: home-nas")
+	}
+}
+
 func TestSafeLogFileName(t *testing.T) {
 	name := LogFileName("2026-06-21", "abc/../def 123")
 

--- a/codex_hook_notify/run.go
+++ b/codex_hook_notify/run.go
@@ -7,11 +7,12 @@ import (
 )
 
 type RunOption struct {
-	Config Config
-	Input  io.Reader
-	Stderr io.Writer
-	Sender Sender
-	Logger Logger
+	Config   Config
+	Input    io.Reader
+	Stderr   io.Writer
+	Sender   Sender
+	Logger   Logger
+	Hostname HostnameFunc
 }
 
 func Run(ctx context.Context, opt RunOption) error {
@@ -32,7 +33,7 @@ func Run(ctx context.Context, opt RunOption) error {
 		return nil
 	}
 
-	messages := BuildMessages(event)
+	messages := BuildMessagesWithMachine(event, ResolveMachineName(opt.Config, opt.Hostname))
 	sentMessages := 0
 	sentWebhooks := 0
 	for _, url := range urls {

--- a/codex_hook_notify/run.go
+++ b/codex_hook_notify/run.go
@@ -32,17 +32,25 @@ func Run(ctx context.Context, opt RunOption) error {
 		return nil
 	}
 
-	text := BuildMessage(event)
-	sent := 0
+	messages := BuildMessages(event)
+	sentMessages := 0
+	sentWebhooks := 0
 	for _, url := range urls {
-		if err := opt.Sender.Send(ctx, url, text); err != nil {
-			report(opt, event.SessionID, "send feishu message failed: %v", err)
-			continue
+		urlSent := 0
+		for _, text := range messages {
+			if err := opt.Sender.Send(ctx, url, text); err != nil {
+				report(opt, event.SessionID, "send feishu message failed: %v", err)
+				continue
+			}
+			urlSent++
 		}
-		sent++
+		if urlSent > 0 {
+			sentWebhooks++
+			sentMessages += urlSent
+		}
 	}
-	if sent > 0 && opt.Logger != nil {
-		if err := opt.Logger.Log(event.SessionID, fmt.Sprintf("event %s sent to %d feishu webhook(s)", event.HookEventName, sent)); err != nil && opt.Stderr != nil {
+	if sentMessages > 0 && opt.Logger != nil {
+		if err := opt.Logger.Log(event.SessionID, fmt.Sprintf("event %s sent to %d feishu webhook(s), %d message(s)", event.HookEventName, sentWebhooks, sentMessages)); err != nil && opt.Stderr != nil {
 			fmt.Fprintf(opt.Stderr, "codex_hook_notify: write log failed: %v\n", err)
 		}
 	}

--- a/codex_hook_notify/run_test.go
+++ b/codex_hook_notify/run_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -93,5 +96,38 @@ func TestRunLogsSuccessfulSend(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	require.Contains(t, logs, "event Stop sent to 1 feishu webhook(s)")
+	require.Contains(t, logs, "event Stop sent to 1 feishu webhook(s), 1 message(s)")
+}
+
+func TestRunSendsEveryMessagePart(t *testing.T) {
+	config := Config{
+		Routes: []Route{
+			{
+				Events:                []string{"Stop"},
+				FeishuCustomRobotURLs: []string{"https://example.com/webhook"},
+			},
+		},
+	}
+	var sent []string
+	var logs []string
+
+	input := `{"hook_event_name":"Stop","session_id":"session-parts","last_assistant_message":` + strconv.Quote(strings.Repeat("long output line\n", 600)) + `}`
+	err := Run(context.Background(), RunOption{
+		Config: config,
+		Input:  bytes.NewBufferString(input),
+		Logger: LoggerFunc(func(sessionID string, message string) error {
+			logs = append(logs, message)
+			return nil
+		}),
+		Sender: SenderFunc(func(ctx context.Context, url string, text string) error {
+			require.Equal(t, "https://example.com/webhook", url)
+			sent = append(sent, text)
+			return nil
+		}),
+	})
+
+	require.NoError(t, err)
+	require.Greater(t, len(sent), 1)
+	require.Contains(t, sent[0], "Codex Hook Reminder [1/")
+	require.Contains(t, logs, fmt.Sprintf("event Stop sent to 1 feishu webhook(s), %d message(s)", len(sent)))
 }

--- a/codex_hook_notify/run_test.go
+++ b/codex_hook_notify/run_test.go
@@ -131,3 +131,29 @@ func TestRunSendsEveryMessagePart(t *testing.T) {
 	require.Contains(t, sent[0], "Codex Hook Reminder [1/")
 	require.Contains(t, logs, fmt.Sprintf("event Stop sent to 1 feishu webhook(s), %d message(s)", len(sent)))
 }
+
+func TestRunUsesConfiguredMachineName(t *testing.T) {
+	config := Config{
+		MachineName: "configured-machine",
+		Routes: []Route{
+			{Events: []string{"Stop"}, FeishuCustomRobotURLs: []string{"https://example.com/webhook"}},
+		},
+	}
+	var sent string
+
+	err := Run(context.Background(), RunOption{
+		Config: config,
+		Input:  bytes.NewBufferString(`{"hook_event_name":"Stop","session_id":"session-machine","last_assistant_message":"summary"}`),
+		Sender: SenderFunc(func(ctx context.Context, url string, text string) error {
+			sent = text
+			return nil
+		}),
+		Hostname: func() (string, error) {
+			return "os-host", nil
+		},
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, sent, "Machine: configured-machine")
+	require.NotContains(t, sent, "Machine: os-host")
+}

--- a/codex_hook_notify/transcript.go
+++ b/codex_hook_notify/transcript.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type transcriptLine struct {
+	Type    string          `json:"type"`
+	Payload json.RawMessage `json:"payload"`
+}
+
+type sessionMeta struct {
+	ID string `json:"id"`
+}
+
+type transcriptMessage struct {
+	Type     string              `json:"type"`
+	Role     string              `json:"role"`
+	Phase    string              `json:"phase"`
+	Content  []transcriptContent `json:"content"`
+	Metadata transcriptMetadata  `json:"metadata"`
+}
+
+type transcriptContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type transcriptMetadata struct {
+	TurnID string `json:"turn_id"`
+}
+
+func transcriptSummary(event HookEvent, codexHome string) string {
+	if codexHome == "" || event.SessionID == "" {
+		return ""
+	}
+	path := findTranscript(codexHome, event.SessionID)
+	if path == "" {
+		return ""
+	}
+	return readTranscriptSummary(path, event.TurnID)
+}
+
+func findTranscript(codexHome string, sessionID string) string {
+	sessionsDir := filepath.Join(codexHome, "sessions")
+	if match := findTranscriptByName(sessionsDir, sessionID); match != "" {
+		return match
+	}
+	return findTranscriptBySessionMeta(sessionsDir, sessionID)
+}
+
+func findTranscriptByName(sessionsDir string, sessionID string) string {
+	var match string
+	_ = filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		if strings.Contains(d.Name(), sessionID) {
+			match = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return match
+}
+
+func findTranscriptBySessionMeta(sessionsDir string, sessionID string) string {
+	var match string
+	_ = filepath.WalkDir(sessionsDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".jsonl") {
+			return nil
+		}
+		if transcriptSessionID(path) == sessionID {
+			match = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	return match
+}
+
+func transcriptSessionID(path string) string {
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 1024), 1024*1024)
+	for scanner.Scan() {
+		var item transcriptLine
+		if err := json.Unmarshal(scanner.Bytes(), &item); err != nil || item.Type != "session_meta" {
+			continue
+		}
+		var meta sessionMeta
+		if err := json.Unmarshal(item.Payload, &meta); err != nil {
+			return ""
+		}
+		return meta.ID
+	}
+	return ""
+}
+
+func readTranscriptSummary(path string, turnID string) string {
+	file, err := os.Open(path)
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 1024), 1024*1024)
+	for scanner.Scan() {
+		text := visibleAssistantText(scanner.Bytes(), turnID)
+		if text != "" {
+			lines = append(lines, text)
+		}
+	}
+	return strings.TrimSpace(strings.Join(lines, "\n\n"))
+}
+
+func visibleAssistantText(line []byte, turnID string) string {
+	var item transcriptLine
+	if err := json.Unmarshal(line, &item); err != nil || item.Type != "response_item" {
+		return ""
+	}
+
+	var msg transcriptMessage
+	if err := json.Unmarshal(item.Payload, &msg); err != nil {
+		return ""
+	}
+	if msg.Type != "message" || msg.Role != "assistant" {
+		return ""
+	}
+	if turnID != "" && msg.Metadata.TurnID != turnID {
+		return ""
+	}
+	if msg.Phase != "" && msg.Phase != "commentary" && msg.Phase != "final_answer" {
+		return ""
+	}
+
+	var parts []string
+	for _, content := range msg.Content {
+		if content.Type == "output_text" && strings.TrimSpace(content.Text) != "" {
+			parts = append(parts, strings.TrimSpace(content.Text))
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/codex_hook_notify/transcript_test.go
+++ b/codex_hook_notify/transcript_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStopSummaryReadsVisibleMessagesFromTranscript(t *testing.T) {
+	codexHome := t.TempDir()
+	sessionID := "session-123"
+	turnID := "turn-123"
+	sessionDir := filepath.Join(codexHome, "sessions", "2026", "06", "21")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	sessionFile := filepath.Join(sessionDir, "rollout-2026-06-21T12-00-00-"+sessionID+".jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"type":"session_meta","payload":{"id":"session-123"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"visible commentary"}],"phase":"commentary","metadata":{"turn_id":"turn-123"}}}
+{"type":"response_item","payload":{"type":"function_call_output","output":"secret tool output","metadata":{"turn_id":"turn-123"}}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"visible final"}],"phase":"final_answer","metadata":{"turn_id":"turn-123"}}}
+`), 0644))
+
+	summary := stopSummary(HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            sessionID,
+		TurnID:               turnID,
+		LastAssistantMessage: "fallback summary",
+	}, codexHome)
+
+	require.Equal(t, "visible commentary\n\nvisible final", summary)
+	require.NotContains(t, summary, "secret tool output")
+	require.NotContains(t, summary, "fallback summary")
+}
+
+func TestStopSummaryFindsTranscriptBySessionMeta(t *testing.T) {
+	codexHome := t.TempDir()
+	sessionDir := filepath.Join(codexHome, "sessions", "2026", "06", "21")
+	require.NoError(t, os.MkdirAll(sessionDir, 0755))
+	sessionFile := filepath.Join(sessionDir, "rollout-without-session-id.jsonl")
+	require.NoError(t, os.WriteFile(sessionFile, []byte(`{"type":"session_meta","payload":{"id":"session-meta"}}
+{"type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"meta matched final"}],"phase":"final_answer","metadata":{"turn_id":"turn-meta"}}}
+`), 0644))
+
+	summary := stopSummary(HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            "session-meta",
+		TurnID:               "turn-meta",
+		LastAssistantMessage: "fallback summary",
+	}, codexHome)
+
+	require.Equal(t, "meta matched final", summary)
+}
+
+func TestStopSummaryFallsBackWhenTranscriptIsMissing(t *testing.T) {
+	summary := stopSummary(HookEvent{
+		HookEventName:        "Stop",
+		SessionID:            "missing-session",
+		TurnID:               "missing-turn",
+		LastAssistantMessage: "fallback summary",
+	}, t.TempDir())
+
+	require.Equal(t, "fallback summary", summary)
+}

--- a/docs/codex_hook_notify.md
+++ b/docs/codex_hook_notify.md
@@ -34,6 +34,7 @@
 
 ```json
 {
+  "machine_name": "home-nas",
   "routes": [
     {
       "events": ["Stop"],
@@ -52,6 +53,27 @@
 ```
 
 一个事件可以配置多个 webhook。没有匹配 route 的事件会被静默跳过。
+
+## 机器名
+
+所有通知都会包含 `Machine:` 字段，用来区分是哪台机器触发了 hook。
+
+机器名取值顺序：
+
+1. 配置文件顶层 `machine_name`，非空时直接使用；
+2. `machine_name` 未配置或为空时，使用当前操作系统 hostname；
+3. hostname 获取失败或为空时，显示 `unknown`。
+
+示例：
+
+```json
+{
+  "machine_name": "home-nas",
+  "routes": []
+}
+```
+
+`machine_name` 只影响通知展示，不参与 route 匹配、日志文件命名或 webhook 选择。
 
 ## Stop summary 来源
 

--- a/docs/codex_hook_notify.md
+++ b/docs/codex_hook_notify.md
@@ -1,9 +1,11 @@
 # codex_hook_notify 使用说明
 
-`codex_hook_notify` 用来接收 Codex lifecycle hook 输入，并通过飞书自定义机器人发送提醒。第一版只提醒两个事件：
+`codex_hook_notify` 用来接收 Codex lifecycle hook 输入，并通过飞书自定义机器人发送提醒。当前提醒两个事件：
 
 1. `Stop`：Codex 本轮完成或停止；
 2. `PermissionRequest`：Codex 等待用户批准命令或工具调用。
+
+`Stop` 提醒会优先读取本机 Codex transcript，推送最后一轮 Codex 用户可见输出，也就是 CLI/App 里能看到的 assistant 文本消息。工具调用的原始 stdout/stderr 不会作为 Stop summary 推送。读取失败时，程序回退到 hook 输入里的 `last_assistant_message`。
 
 提醒失败不会阻塞 Codex。程序会向 stderr 输出错误，并写入本地日志。
 
@@ -50,6 +52,18 @@
 ```
 
 一个事件可以配置多个 webhook。没有匹配 route 的事件会被静默跳过。
+
+## Stop summary 来源
+
+`Stop` 事件的 hook 输入不一定包含完整输出。为了补全最后一轮内容，程序会按下面顺序取 summary：
+
+1. 从 `CODEX_HOME/sessions` 读取本地 transcript；如果 `CODEX_HOME` 未设置，默认使用 `~/.codex/sessions`；
+2. 先按 session id 匹配 transcript 文件名；匹配不到时，再读取 `session_meta.payload.id` 做一次兜底匹配；
+3. 只提取同一 `turn_id` 下的 assistant `message`，并保留 `commentary` 和 `final_answer` 等用户可见文本；
+4. 找不到 transcript、格式变化或解析失败时，回退到 `last_assistant_message`；
+5. 仍然没有内容时，发送 `No summary available.`。
+
+长 summary 会拆成多条飞书 text 消息，标题带 `Codex Hook Reminder [1/N]` 这样的分片标记。推送内容原样发送，不做敏感信息脱敏；如果最后一轮 Codex 输出里包含路径、配置片段、token 或其他敏感内容，它们会进入配置的飞书群。
 
 ## Linux 安装
 

--- a/sample/life_tools/codex_hook_notify.json
+++ b/sample/life_tools/codex_hook_notify.json
@@ -1,4 +1,5 @@
 {
+  "machine_name": "",
   "routes": [
     {
       "events": ["Stop"],


### PR DESCRIPTION
## Summary
- Read local Codex transcripts for Stop hooks and send the last turn's user-visible assistant output.
- Split long Stop summaries across multiple Feishu text messages instead of truncating them.
- Document transcript lookup, fallback behavior, and raw-send privacy risk.

## Test Plan
- go test ./...
- go test ./codex_hook_notify -count=1
- ./build.sh