### PR TITLE
feat: improve life tools installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ __pycache__/
 .venv/
 venv/
 .env
+# Go test scratch directories
+renameV1/tmp/

--- a/README.MD
+++ b/README.MD
@@ -2,6 +2,42 @@
 
 咸鱼程序员在工作之余（如果有的话）可能用到的小工具。
 
+## 安装
+
+支持 Linux 和 macOS。仓库根目录执行下面命令，默认安装稳定工具：`renameV1`、`check_keywords`、`retry_exec`、`codex_hook_notify`、`video_subtitle`。
+
+```bash
+./install.sh
+```
+
+只安装指定工具：
+
+```bash
+./install.sh --tool retry_exec
+./install.sh --tool renameV1 --tool check_keywords
+./install.sh --tools retry_exec,codex_hook_notify
+```
+
+安装到自定义前缀和配置目录：
+
+```bash
+./install.sh --prefix "$HOME/.local" --config-dir "$HOME/.config/life_tools"
+```
+
+`video_subtitle` 的 Python 依赖默认不会自动安装，需要脚本安装依赖时显式执行：
+
+```bash
+./install.sh --tool video_subtitle --with-python-deps
+```
+
+`dav` 是实验工具，当前源码里有硬编码 BasicAuth，不在默认安装范围内。确实需要时再显式执行：
+
+```bash
+./install.sh --tool dav
+```
+
+完整安装说明和 AI Agent 快速安装步骤见：[docs/install.md](docs/install.md)。
+
 ## 哪些工具？
 
 ## retry_exec
@@ -22,12 +58,13 @@
 ![企微提醒](https://mcoder-image-storage.oss-cn-hangzhou.aliyuncs.com/image/25261058_42e17078663144a3.jpg)
 
 
-**配置**
+**安装与配置**
 
-1. 将 sample/life_tools 下的示例配置文件放在在`/etc/life_tools/retry_exec.json`这里，确保有读权限；
-`sudo chmod a+r /etc/life_tools/retry_exec.json`
-2. 提前创建好日志路径，确保有读写权限 `mkdir -p /var/log/retry_exec`;
-3. 然后就可以正常使用啦；
+```bash
+./install.sh --tool retry_exec
+```
+
+脚本会安装 `retry_exec`，并在 `/etc/life_tools/retry_exec.json` 不存在时写入示例配置，还会创建 `/var/log/retry_exec`。安装后编辑配置里的提醒机器人地址和日志路径。
 
 
 ![使用照片](https://mcoder-image-storage.oss-cn-hangzhou.aliyuncs.com/image/25261103_2f53b1735abdb443.jpg)
@@ -38,7 +75,13 @@
 命令行批量重命名文件名的工具。我在家里有一台 NAS，安装了 emby，但每次下载动漫时，因为文件名命名不规范，导致 emby 无法识别，修改文件名过于繁琐，
 所以实现了一个粗糙版本的文件名批量命名工具，根据顺序排序重命名。
 
-构建方式，需要先配置 golang 的运行环境，在工程根路径下执行 `./build.sh` 命令。
+安装方式，需要先配置 Golang 的运行环境，在工程根路径下执行：
+
+```bash
+./install.sh --tool renameV1
+```
+
+只想构建不安装时，可以执行：
 
 ```bash
 ./build.sh
@@ -107,28 +150,22 @@ Codex 生命周期提醒工具。程序从 stdin 读取 Codex hook JSON，根据
 }
 ```
 
-构建：
-
-```bash
-./build.sh
-```
-
 安装：
 
 ```bash
-./install.sh
+./install.sh --tool codex_hook_notify
 ```
 
 默认安装只会构建程序、安装 `/usr/local/bin/codex_hook_notify`、创建配置样例和日志目录，不会修改 Codex 全局 hook。确认配置后，显式执行下面命令安装 `Stop` hook：
 
 ```bash
-./install.sh --install-codex-hook
+./install.sh --tool codex_hook_notify --install-codex-hook
 ```
 
 `PermissionRequest` 在 approval 模式下提醒很多，默认不安装；如果旧版本已经安装过本工具的 `PermissionRequest` hook，默认安装命令会把它移除。确实需要审批提醒时再显式安装：
 
 ```bash
-./install.sh --install-codex-hook --with-permission-request
+./install.sh --tool codex_hook_notify --install-codex-hook --with-permission-request
 ```
 
 日志目录按系统选择：Linux 使用 `/var/log/codex_hook_notify`，macOS 使用 `~/Library/Logs/codex_hook_notify`，其他系统使用 `~/.codex_hook_notify/logs`。发送失败只写 stderr 和日志，程序仍返回 0，不阻塞 Codex。
@@ -139,10 +176,22 @@ Codex 生命周期提醒工具。程序从 stdin 读取 Codex hook JSON，根据
 
 完整使用说明、工作流程、项目结构和排障方法见：[docs/video_subtitle.md](docs/video_subtitle.md)。
 
-安装依赖：
+安装：
+
+```bash
+./install.sh --tool video_subtitle
+```
+
+安装 Python 依赖：
 
 ```bash
 python3 -m pip install -r video_subtitle/requirements.txt
+```
+
+也可以让安装脚本顺手安装 Python 依赖：
+
+```bash
+./install.sh --tool video_subtitle --with-python-deps
 ```
 
 配置文件示例在 `sample/life_tools/video_subtitle.json`，真实配置默认放到 `/etc/life_tools/video_subtitle.json`。
@@ -150,15 +199,15 @@ python3 -m pip install -r video_subtitle/requirements.txt
 生成字幕：
 
 ```bash
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mp4
+video_subtitle --input /path/to/video.mp4
 ```
 
 常用调试命令：
 
 ```bash
 # 只重跑翻译，复用 ASR 和切分缓存
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mp4 --force-translate
+video_subtitle --input /path/to/video.mp4 --force-translate
 
 # 跳过 ASR，强制从 ASR words 的 LLM 切分和翻译开始
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mp4 --force-split --force-translate
+video_subtitle --input /path/to/video.mp4 --force-split --force-translate
 ```

--- a/docs/codex_hook_notify.md
+++ b/docs/codex_hook_notify.md
@@ -92,7 +92,7 @@
 在仓库根目录执行：
 
 ```bash
-./install.sh
+./install.sh --tool codex_hook_notify
 ```
 
 脚本会做这些事：
@@ -105,13 +105,13 @@
 填写真实 webhook 后，安装全局 Codex hook。默认只安装 `Stop`，也就是 Codex 完成或停止时提醒：
 
 ```bash
-./install.sh --install-codex-hook
+./install.sh --tool codex_hook_notify --install-codex-hook
 ```
 
 `PermissionRequest` 在 approval 模式下会非常频繁，默认不安装。默认安装命令也会移除本工具旧版本安装过的 `PermissionRequest` hook。如果你明确需要等待审批提醒，再执行：
 
 ```bash
-./install.sh --install-codex-hook --with-permission-request
+./install.sh --tool codex_hook_notify --install-codex-hook --with-permission-request
 ```
 
 ## macOS 安装
@@ -119,7 +119,7 @@
 在仓库根目录执行：
 
 ```bash
-./install.sh
+./install.sh --tool codex_hook_notify
 ```
 
 脚本会把程序安装到 `/usr/local/bin/codex_hook_notify`，配置仍放在 `/etc/life_tools/codex_hook_notify.json`。日志目录会创建在：
@@ -131,13 +131,13 @@
 填写真实 webhook 后，安装全局 Codex hook。默认只安装 `Stop`，也就是 Codex 完成或停止时提醒：
 
 ```bash
-./install.sh --install-codex-hook
+./install.sh --tool codex_hook_notify --install-codex-hook
 ```
 
 `PermissionRequest` 在 approval 模式下会非常频繁，默认不安装。默认安装命令也会移除本工具旧版本安装过的 `PermissionRequest` hook。如果你明确需要等待审批提醒，再执行：
 
 ```bash
-./install.sh --install-codex-hook --with-permission-request
+./install.sh --tool codex_hook_notify --install-codex-hook --with-permission-request
 ```
 
 macOS 上如果 `/usr/local/bin` 或 `/etc/life_tools` 需要管理员权限，脚本会通过 `sudo` 请求权限。

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,148 @@
+# 安装说明
+
+这份文档面向人工用户和 AI Agent。目标是快速判断该装什么、怎么装、装完怎么验证。不要猜工具名，直接按下面的清单执行。
+
+## 支持范围
+
+- 系统：Linux、macOS。
+- Shell：`bash`。
+- Go 工具：需要本机有 `go`，版本以 `go.mod` 为准。
+- `video_subtitle`：需要 `python3`；运行时还需要 `ffmpeg` 和 `ffprobe`。
+- 默认安装路径：可执行文件放到 `/usr/local/bin`，Python 工具文件放到 `/usr/local/lib/life_tools`。
+- 默认配置路径：`/etc/life_tools`，可用 `--config-dir` 改变安装脚本写入位置。
+
+写入 `/usr/local`、`/etc/life_tools`、`/var/log` 时可能需要 `sudo`。脚本会在需要时调用 `sudo`，不会覆盖已经存在的配置文件。
+
+## 工具清单
+
+| 工具名 | 安装后的命令 | 类型 | 默认安装 | 配置文件 |
+|---|---|---|---|---|
+| `renameV1` | `renameV1` | Go | 是 | 使用工作目录下的 `rename_v1.json` |
+| `check_keywords` | `check_keywords` | Go | 是 | `/etc/life_tools/check_keywords.json` |
+| `retry_exec` | `retry_exec` | Go | 是 | `/etc/life_tools/retry_exec.json` |
+| `codex_hook_notify` | `codex_hook_notify` | Go | 是 | `/etc/life_tools/codex_hook_notify.json` |
+| `video_subtitle` | `video_subtitle` | Python | 是 | `/etc/life_tools/video_subtitle.json` |
+| `dav` | `dav` | Go | 否 | 无 |
+
+`dav` 当前是实验工具，源码里有硬编码 BasicAuth，不要默认安装到用户机器。确实要装时使用 `--tool dav` 或 `--all`。
+
+## 快速安装
+
+安装默认稳定工具：
+
+```bash
+./install.sh
+```
+
+只安装指定工具：
+
+```bash
+./install.sh --tool retry_exec
+./install.sh --tool renameV1 --tool check_keywords
+./install.sh --tools retry_exec,codex_hook_notify
+```
+
+安装到自定义前缀：
+
+```bash
+./install.sh --prefix "$HOME/.local"
+```
+
+配置目录也可以改，适合无 sudo 权限或测试安装：
+
+```bash
+./install.sh --prefix "$HOME/.local" --config-dir "$HOME/.config/life_tools"
+```
+
+这只改变安装脚本写入示例配置的位置。部分工具源码里的默认配置路径仍是 `/etc/life_tools`，运行时需要用命令参数指定自定义配置路径。
+
+## video_subtitle
+
+只安装 `video_subtitle`：
+
+```bash
+./install.sh --tool video_subtitle
+```
+
+脚本会复制 Python 工具文件，安装 `/usr/local/bin/video_subtitle` 包装命令，并安装示例配置到：
+
+```text
+/etc/life_tools/video_subtitle.json
+```
+
+Python 依赖默认不自动安装，避免脚本改坏用户的 Python 环境。需要脚本顺手安装依赖时显式加参数：
+
+```bash
+./install.sh --tool video_subtitle --with-python-deps
+```
+
+运行前还要确保系统里有：
+
+```bash
+ffmpeg
+ffprobe
+```
+
+## codex_hook_notify
+
+只安装命令和示例配置：
+
+```bash
+./install.sh --tool codex_hook_notify
+```
+
+安装 Codex `Stop` hook：
+
+```bash
+./install.sh --tool codex_hook_notify --install-codex-hook
+```
+
+同时安装 `PermissionRequest` hook：
+
+```bash
+./install.sh --tool codex_hook_notify --install-codex-hook --with-permission-request
+```
+
+`PermissionRequest` 在 approval 模式下会很频繁，不要默认开启。
+
+## AI Agent 安装步骤
+
+1. 进入仓库根目录。
+2. 读取本文件和 `README.MD`，确认目标工具名。
+3. 执行 `./install.sh --tool <工具名>`；需要多个工具就重复 `--tool`。
+4. 如果安装 `video_subtitle`，确认 `python3`、`ffmpeg`、`ffprobe` 和 Python 依赖。
+5. 编辑 `/etc/life_tools/*.json` 中的真实配置，密钥和 webhook 不要写回仓库。
+6. 用 `command -v <命令>` 和对应命令的 `--help` 或 `-h` 做最小验证。
+
+不要在没有用户确认的情况下执行 `--all`，因为它会安装实验性的 `dav`。
+
+## 验证命令
+
+```bash
+command -v renameV1
+command -v check_keywords
+command -v retry_exec
+command -v codex_hook_notify
+command -v video_subtitle
+```
+
+常用帮助命令：
+
+```bash
+renameV1 -h
+check_keywords -h
+retry_exec --help
+codex_hook_notify -h
+video_subtitle --help
+```
+
+## 脚本行为
+
+- Go 工具会先构建到 `output/`，再安装到目标 `bin` 目录。
+- 示例配置只在目标文件不存在时安装，已有配置不会被覆盖。
+- `retry_exec` 会创建 `/var/log/retry_exec` 并设置为当前用户可写。
+- `codex_hook_notify` 的日志目录按系统选择：
+  - Linux：`/var/log/codex_hook_notify`
+  - macOS：`~/Library/Logs/codex_hook_notify`
+  - 其他系统：`~/.codex_hook_notify/logs`
+- `video_subtitle` 会复制 `video_subtitle/` 到 `<prefix>/lib/life_tools/video_subtitle`，再安装一个同名包装命令。

--- a/docs/video_subtitle.md
+++ b/docs/video_subtitle.md
@@ -6,45 +6,51 @@
 
 ## 使用方法
 
+安装工具：
+
+```bash
+./install.sh --tool video_subtitle
+```
+
 安装 Python 依赖：
 
 ```bash
 python3 -m pip install -r video_subtitle/requirements.txt
 ```
 
-准备配置文件：
+也可以让安装脚本顺手安装 Python 依赖：
 
 ```bash
-sudo mkdir -p /etc/life_tools
-sudo cp sample/life_tools/video_subtitle.json /etc/life_tools/video_subtitle.json
-sudo chmod a+r /etc/life_tools/video_subtitle.json
+./install.sh --tool video_subtitle --with-python-deps
 ```
+
+安装脚本会在 `/etc/life_tools/video_subtitle.json` 不存在时写入示例配置。
 
 编辑 `/etc/life_tools/video_subtitle.json`，填入 TOS、ASR、LLM、可选 TMDB 配置。不要把真实密钥写进仓库。
 
 生成字幕：
 
 ```bash
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv
+video_subtitle --input /path/to/video.mkv
 ```
 
 常用参数：
 
 ```bash
 # 跳过交互确认，不在缺少本地 NFO 时发起 TMDB 搜索确认
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --yes
+video_subtitle --input /path/to/video.mkv --yes
 
 # 强制重新跑 ASR，会重新抽音频、上传 TOS、调用 ASR
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --force-asr
+video_subtitle --input /path/to/video.mkv --force-asr
 
 # 只强制重新翻译，复用 ASR 和 subtitle_units
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --force-translate
+video_subtitle --input /path/to/video.mkv --force-translate
 
 # 强制重新做 ASR words 的 LLM 切分，并重新翻译
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --force-split --force-translate
+video_subtitle --input /path/to/video.mkv --force-split --force-translate
 
 # 指定输出路径
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --output /path/to/video.zh-CN.srt
+video_subtitle --input /path/to/video.mkv --output /path/to/video.zh-CN.srt
 ```
 
 默认输出路径是视频同目录的 `视频名.zh-CN.srt`。如果文件已存在，会尝试 `视频名.zh-CN_1.srt` 到 `视频名.zh-CN_100.srt`。
@@ -70,7 +76,7 @@ python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv --output /pa
 ```bash
 VIDEO_SUBTITLE_LLM_API_KEY=xxx \
 VIDEO_SUBTITLE_LLM_MODEL=doubao-seed-2-0-lite-260428 \
-python3 video_subtitle/video_subtitle.py --input /path/to/video.mkv
+video_subtitle --input /path/to/video.mkv
 ```
 
 LLM 相关默认策略：

--- a/install.sh
+++ b/install.sh
@@ -1,76 +1,413 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BIN_NAME="codex_hook_notify"
-OUTPUT_BIN="$ROOT_DIR/output/$BIN_NAME"
-INSTALL_BIN="/usr/local/bin/$BIN_NAME"
-CONFIG_DIR="/etc/life_tools"
-CONFIG_FILE="$CONFIG_DIR/codex_hook_notify.json"
-SAMPLE_CONFIG="$ROOT_DIR/sample/life_tools/codex_hook_notify.json"
-OS_NAME="$(uname -s)"
-case "$OS_NAME" in
-  Linux)
-    LOG_DIR="/var/log/codex_hook_notify"
-    ;;
-  Darwin)
-    LOG_DIR="$HOME/Library/Logs/codex_hook_notify"
-    ;;
-  *)
-    LOG_DIR="$HOME/.codex_hook_notify/logs"
-    ;;
-esac
+OUTPUT_DIR="$ROOT_DIR/output"
+PREFIX="/usr/local"
+CONFIG_DIR="${LIFE_TOOLS_CONFIG_DIR:-/etc/life_tools}"
 HOOKS_FILE="$HOME/.codex/hooks.json"
+OS_NAME="$(uname -s)"
+
+STABLE_TOOLS=(renameV1 check_keywords retry_exec codex_hook_notify video_subtitle)
+ALL_TOOLS=(renameV1 check_keywords retry_exec codex_hook_notify video_subtitle dav)
+REQUESTED_TOOLS=()
+SELECTED_TOOLS=()
+INSTALL_ALL=0
 INSTALL_CODEX_HOOK=0
 WITH_PERMISSION_REQUEST=0
+WITH_PYTHON_DEPS=0
 
-for arg in "$@"; do
-  case "$arg" in
-    --install-codex-hook)
-      INSTALL_CODEX_HOOK=1
-      ;;
-    --with-permission-request)
-      WITH_PERMISSION_REQUEST=1
-      ;;
-    -h|--help)
-      echo "Usage: ./install.sh [--install-codex-hook] [--with-permission-request]"
-      exit 0
-      ;;
-    *)
-      echo "unknown argument: $arg" >&2
-      exit 1
-      ;;
-  esac
-done
+usage() {
+  cat <<'EOF'
+Usage:
+  ./install.sh [options]
 
-command -v go >/dev/null 2>&1 || {
-  echo "go command not found" >&2
-  exit 1
+Options:
+  --tool NAME                  Install only this tool. Can be repeated.
+  --tool=NAME                  Same as --tool NAME.
+  --tools a,b                  Install a comma-separated tool list.
+  --all                        Install all tools, including experimental dav.
+  --prefix DIR                 Install executables under DIR/bin. Default: /usr/local.
+  --config-dir DIR             Install sample configs under DIR. Default: /etc/life_tools.
+  --with-python-deps           Run python3 -m pip install for video_subtitle dependencies.
+  --install-codex-hook         Install codex_hook_notify Stop hook.
+  --with-permission-request    Also install codex_hook_notify PermissionRequest hook.
+  -h, --help                   Show this help.
+
+Stable tools installed by default:
+  renameV1, check_keywords, retry_exec, codex_hook_notify, video_subtitle
+
+All tool names:
+  renameV1, check_keywords, retry_exec, codex_hook_notify, video_subtitle, dav
+
+Examples:
+  ./install.sh
+  ./install.sh --tool retry_exec
+  ./install.sh --tool renameV1 --tool check_keywords
+  ./install.sh --tool video_subtitle --with-python-deps
+  ./install.sh --tool codex_hook_notify --install-codex-hook
+EOF
 }
 
-mkdir -p "$ROOT_DIR/output"
-go build -v -o "$OUTPUT_BIN" "$ROOT_DIR/codex_hook_notify/..."
+run_privileged() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+    return
+  fi
+  if ! command -v sudo >/dev/null 2>&1; then
+    echo "sudo command not found; cannot write privileged path" >&2
+    exit 1
+  fi
+  sudo "$@"
+}
 
-sudo install -m 0755 "$OUTPUT_BIN" "$INSTALL_BIN"
-sudo mkdir -p "$CONFIG_DIR"
-if [ "$OS_NAME" = "Linux" ]; then
-  sudo mkdir -p "$LOG_DIR"
-  sudo chown "$(id -u):$(id -g)" "$LOG_DIR"
-  sudo chmod 0755 "$LOG_DIR"
-else
-  mkdir -p "$LOG_DIR"
-  chmod 0755 "$LOG_DIR"
-fi
+require_command() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "$1 command not found" >&2
+    exit 1
+  fi
+}
 
-if [ ! -f "$CONFIG_FILE" ]; then
-  sudo install -m 0644 "$SAMPLE_CONFIG" "$CONFIG_FILE"
-  echo "installed sample config: $CONFIG_FILE"
-else
-  echo "config exists, skip overwrite: $CONFIG_FILE"
-fi
+ensure_dir() {
+  local dir="$1"
+  local mode="$2"
 
-if [ "$INSTALL_CODEX_HOOK" -eq 1 ]; then
-  python3 - "$HOOKS_FILE" "$INSTALL_BIN" "$CONFIG_FILE" "$WITH_PERMISSION_REQUEST" <<'PYCODE'
+  if [ -d "$dir" ]; then
+    return
+  fi
+  if mkdir -p "$dir" 2>/dev/null; then
+    chmod "$mode" "$dir" 2>/dev/null || true
+    return
+  fi
+  run_privileged mkdir -p "$dir"
+  run_privileged chmod "$mode" "$dir"
+}
+
+ensure_user_writable_dir() {
+  local dir="$1"
+
+  if [ -d "$dir" ] && [ -w "$dir" ]; then
+    chmod 0755 "$dir" 2>/dev/null || true
+    return
+  fi
+  if mkdir -p "$dir" 2>/dev/null && [ -w "$dir" ]; then
+    chmod 0755 "$dir" 2>/dev/null || true
+    return
+  fi
+  run_privileged mkdir -p "$dir"
+  run_privileged chown "$(id -u):$(id -g)" "$dir"
+  run_privileged chmod 0755 "$dir"
+}
+
+install_file() {
+  local src="$1"
+  local dest="$2"
+  local mode="$3"
+
+  ensure_dir "$(dirname "$dest")" 0755
+  if install -m "$mode" "$src" "$dest" 2>/dev/null; then
+    return
+  fi
+  run_privileged install -m "$mode" "$src" "$dest"
+}
+
+install_executable() {
+  install_file "$1" "$2" 0755
+  echo "installed executable: $2"
+}
+
+install_config_if_missing() {
+  local sample="$1"
+  local dest="$2"
+
+  ensure_dir "$CONFIG_DIR" 0755
+  if [ -f "$dest" ]; then
+    echo "config exists, skip overwrite: $dest"
+    return
+  fi
+  install_file "$sample" "$dest" 0644
+  echo "installed sample config: $dest"
+}
+
+copy_dir_contents() {
+  local src="$1"
+  local dest="$2"
+
+  ensure_dir "$dest" 0755
+  if cp -R "$src/." "$dest/" 2>/dev/null; then
+    chmod -R a+rX "$dest" 2>/dev/null || true
+    return
+  fi
+  run_privileged cp -R "$src/." "$dest/"
+  run_privileged chmod -R a+rX "$dest"
+}
+
+contains_tool() {
+  local target="$1"
+  shift
+  local item
+  for item in "$@"; do
+    if [ "$item" = "$target" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+normalize_tool_name() {
+  case "$1" in
+    rename|rename_v1|renameV1)
+      echo "renameV1"
+      ;;
+    check-keywords|check_keywords|save_work)
+      echo "check_keywords"
+      ;;
+    retry|retry-exec|retry_exec)
+      echo "retry_exec"
+      ;;
+    codex|codex-hook-notify|codex_hook_notify)
+      echo "codex_hook_notify"
+      ;;
+    video|video-subtitle|video_subtitle)
+      echo "video_subtitle"
+      ;;
+    dav|webdav)
+      echo "dav"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+add_requested_tool() {
+  local normalized
+  if ! normalized="$(normalize_tool_name "$1")"; then
+    echo "unknown tool: $1" >&2
+    echo "run ./install.sh --help to list supported tools" >&2
+    exit 1
+  fi
+  if ! contains_tool "$normalized" "${REQUESTED_TOOLS[@]}"; then
+    REQUESTED_TOOLS+=("$normalized")
+  fi
+}
+
+add_requested_tools_csv() {
+  local value="$1"
+  local names=()
+  local old_ifs="$IFS"
+  IFS=,
+  read -r -a names <<< "$value"
+  IFS="$old_ifs"
+
+  local name
+  for name in "${names[@]}"; do
+    if [ -n "$name" ]; then
+      add_requested_tool "$name"
+    fi
+  done
+}
+
+parse_args() {
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --tool)
+        if [ "$#" -lt 2 ]; then
+          echo "--tool requires a tool name" >&2
+          exit 1
+        fi
+        add_requested_tool "$2"
+        shift 2
+        ;;
+      --tool=*)
+        add_requested_tool "${1#--tool=}"
+        shift
+        ;;
+      --tools)
+        if [ "$#" -lt 2 ]; then
+          echo "--tools requires a comma-separated tool list" >&2
+          exit 1
+        fi
+        add_requested_tools_csv "$2"
+        shift 2
+        ;;
+      --tools=*)
+        add_requested_tools_csv "${1#--tools=}"
+        shift
+        ;;
+      --all)
+        INSTALL_ALL=1
+        shift
+        ;;
+      --prefix)
+        if [ "$#" -lt 2 ]; then
+          echo "--prefix requires a directory" >&2
+          exit 1
+        fi
+        PREFIX="${2%/}"
+        shift 2
+        ;;
+      --prefix=*)
+        PREFIX="${1#--prefix=}"
+        PREFIX="${PREFIX%/}"
+        shift
+        ;;
+      --config-dir)
+        if [ "$#" -lt 2 ]; then
+          echo "--config-dir requires a directory" >&2
+          exit 1
+        fi
+        CONFIG_DIR="${2%/}"
+        shift 2
+        ;;
+      --config-dir=*)
+        CONFIG_DIR="${1#--config-dir=}"
+        CONFIG_DIR="${CONFIG_DIR%/}"
+        shift
+        ;;
+      --with-python-deps)
+        WITH_PYTHON_DEPS=1
+        shift
+        ;;
+      --install-codex-hook)
+        INSTALL_CODEX_HOOK=1
+        shift
+        ;;
+      --with-permission-request)
+        WITH_PERMISSION_REQUEST=1
+        shift
+        ;;
+      -h|--help)
+        usage
+        exit 0
+        ;;
+      *)
+        echo "unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+select_tools() {
+  if [ "$INSTALL_ALL" -eq 1 ]; then
+    SELECTED_TOOLS=("${ALL_TOOLS[@]}")
+  elif [ "${#REQUESTED_TOOLS[@]}" -gt 0 ]; then
+    SELECTED_TOOLS=("${REQUESTED_TOOLS[@]}")
+  else
+    SELECTED_TOOLS=("${STABLE_TOOLS[@]}")
+  fi
+
+  if [ "$INSTALL_CODEX_HOOK" -eq 1 ] && ! contains_tool codex_hook_notify "${SELECTED_TOOLS[@]}"; then
+    echo "--install-codex-hook requires installing codex_hook_notify" >&2
+    exit 1
+  fi
+}
+
+needs_go() {
+  local tool
+  for tool in "${SELECTED_TOOLS[@]}"; do
+    case "$tool" in
+      renameV1|check_keywords|retry_exec|codex_hook_notify|dav)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+needs_python() {
+  local tool
+  for tool in "${SELECTED_TOOLS[@]}"; do
+    case "$tool" in
+      video_subtitle|codex_hook_notify)
+        return 0
+        ;;
+    esac
+  done
+  return 1
+}
+
+build_go_tool() {
+  local tool="$1"
+  local bin_name="$2"
+  local package_path="$3"
+  local output_bin="$OUTPUT_DIR/$bin_name"
+
+  mkdir -p "$OUTPUT_DIR"
+  echo "building $tool"
+  (cd "$ROOT_DIR" && go build -v -o "$output_bin" "$package_path")
+}
+
+install_go_tool() {
+  local tool="$1"
+  local bin_name="$2"
+  local package_path="$3"
+
+  build_go_tool "$tool" "$bin_name" "$package_path"
+  install_executable "$OUTPUT_DIR/$bin_name" "$PREFIX/bin/$bin_name"
+}
+
+codex_log_dir() {
+  case "$OS_NAME" in
+    Linux)
+      echo "/var/log/codex_hook_notify"
+      ;;
+    Darwin)
+      echo "$HOME/Library/Logs/codex_hook_notify"
+      ;;
+    *)
+      echo "$HOME/.codex_hook_notify/logs"
+      ;;
+  esac
+}
+
+install_rename_v1() {
+  install_go_tool renameV1 renameV1 ./renameV1/...
+  echo "renameV1 uses per-directory config files; sample: sample/life_tools/rename_v1.json"
+}
+
+install_check_keywords() {
+  install_go_tool check_keywords check_keywords ./save_work/...
+  install_config_if_missing "$ROOT_DIR/sample/life_tools/check_keywords.json" "$CONFIG_DIR/check_keywords.json"
+}
+
+install_retry_exec() {
+  install_go_tool retry_exec retry_exec ./retry_exec/...
+  install_config_if_missing "$ROOT_DIR/sample/life_tools/retry_exec.json" "$CONFIG_DIR/retry_exec.json"
+  ensure_user_writable_dir "/var/log/retry_exec"
+}
+
+install_codex_hook_notify() {
+  local config_file="$CONFIG_DIR/codex_hook_notify.json"
+  local log_dir
+
+  install_go_tool codex_hook_notify codex_hook_notify ./codex_hook_notify/...
+  install_config_if_missing "$ROOT_DIR/sample/life_tools/codex_hook_notify.json" "$config_file"
+  log_dir="$(codex_log_dir)"
+  ensure_user_writable_dir "$log_dir"
+
+  if [ "$INSTALL_CODEX_HOOK" -eq 1 ]; then
+    install_codex_hook "$PREFIX/bin/codex_hook_notify" "$config_file"
+    return
+  fi
+
+  cat <<EOF
+codex_hook_notify installed to $PREFIX/bin/codex_hook_notify
+
+Next steps:
+1. Edit $config_file and fill feishu_custom_robot_urls.
+2. Run ./install.sh --tool codex_hook_notify --install-codex-hook to install the Stop hook.
+3. Optional: add --with-permission-request to also install PermissionRequest reminders.
+EOF
+}
+
+install_codex_hook() {
+  local install_bin="$1"
+  local config_file="$2"
+
+  require_command python3
+  python3 - "$HOOKS_FILE" "$install_bin" "$config_file" "$WITH_PERMISSION_REQUEST" <<'PYCODE'
 import json
 import sys
 from pathlib import Path
@@ -134,13 +471,91 @@ if changed:
 else:
     print(f"hooks already installed in {hooks_file}")
 PYCODE
-else
-  cat <<EOF
-codex_hook_notify installed to $INSTALL_BIN
+}
 
-Next steps:
-1. Edit $CONFIG_FILE and fill feishu_custom_robot_urls.
-2. Run ./install.sh --install-codex-hook to install the Stop hook.
-3. Optional: run ./install.sh --install-codex-hook --with-permission-request to also install PermissionRequest reminders.
+install_video_subtitle() {
+  local lib_dir="$PREFIX/lib/life_tools/video_subtitle"
+  local wrapper="$OUTPUT_DIR/video_subtitle"
+
+  require_command python3
+  mkdir -p "$OUTPUT_DIR"
+  copy_dir_contents "$ROOT_DIR/video_subtitle" "$lib_dir"
+  install_config_if_missing "$ROOT_DIR/sample/life_tools/video_subtitle.json" "$CONFIG_DIR/video_subtitle.json"
+
+  cat > "$wrapper" <<EOF
+#!/bin/sh
+exec python3 "$lib_dir/video_subtitle.py" "\$@"
 EOF
-fi
+  chmod 0755 "$wrapper"
+  install_executable "$wrapper" "$PREFIX/bin/video_subtitle"
+
+  if [ "$WITH_PYTHON_DEPS" -eq 1 ]; then
+    python3 -m pip install -r "$ROOT_DIR/video_subtitle/requirements.txt"
+  else
+    cat <<EOF
+video_subtitle Python package files installed to $lib_dir
+Python dependencies were not installed.
+Run this if the runtime environment does not already have them:
+  python3 -m pip install -r $ROOT_DIR/video_subtitle/requirements.txt
+EOF
+  fi
+}
+
+install_dav() {
+  cat <<'EOF'
+warning: dav is experimental and has hard-coded BasicAuth in current source.
+Do not expose it to an untrusted network without reviewing webdav/main.go.
+EOF
+  install_go_tool dav dav ./webdav/...
+}
+
+install_selected_tool() {
+  case "$1" in
+    renameV1)
+      install_rename_v1
+      ;;
+    check_keywords)
+      install_check_keywords
+      ;;
+    retry_exec)
+      install_retry_exec
+      ;;
+    codex_hook_notify)
+      install_codex_hook_notify
+      ;;
+    video_subtitle)
+      install_video_subtitle
+      ;;
+    dav)
+      install_dav
+      ;;
+    *)
+      echo "unsupported tool: $1" >&2
+      exit 1
+      ;;
+  esac
+}
+
+main() {
+  local tool
+
+  parse_args "$@"
+  select_tools
+
+  if needs_go; then
+    require_command go
+  fi
+  if needs_python; then
+    require_command python3
+  fi
+
+  echo "selected tools: ${SELECTED_TOOLS[*]}"
+  echo "install prefix: $PREFIX"
+  echo "config dir: $CONFIG_DIR"
+
+  for tool in "${SELECTED_TOOLS[@]}"; do
+    install_selected_tool "$tool"
+  done
+}
+
+main "$@"

--- a/renameV1/file_test.go
+++ b/renameV1/file_test.go
@@ -19,15 +19,23 @@ func TestListDirFiles(t *testing.T) {
 }
 
 func TestRenameFileNameWithSpace(t *testing.T) {
+	const tmpDir = "./tmp"
 
-	f, err := os.Create("./testData/file name with space.mkv")
-	require.NoError(t, err)
-	f.Write([]byte("test"))
-	err = f.Close()
-	require.NoError(t, err)
+	require.NoError(t, os.RemoveAll(tmpDir))
+	require.NoError(t, os.MkdirAll(tmpDir, 0755))
+	t.Cleanup(func() {
+		require.NoError(t, os.RemoveAll(tmpDir))
+	})
 
-	err = os.Rename("./testData/file name with space.mkv", "./testData/file_name_with_space.mkv")
+	oldName := tmpDir + "/file name with space.mkv"
+	newName := tmpDir + "/file_name_with_space.mkv"
+	f, err := os.Create(oldName)
 	require.NoError(t, err)
-	err = os.Remove("./testData/file_name_with_space.mkv")
+	_, err = f.Write([]byte("test"))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	require.NoError(t, os.Rename(oldName, newName))
+	_, err = os.Stat(newName)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
- expand install.sh to install all stable tools or only selected tools on Linux/macOS
- add docs/install.md for humans and AI agents
- update README and tool docs with the new install commands

## Verification
- bash -n install.sh
- git diff --check
- ./install.sh --help
- ./install.sh --tool check_keywords --prefix /tmp/life_tools-install-submit-go --config-dir /tmp/life_tools-install-submit-go/etc
- ./install.sh --tool video_subtitle --prefix /tmp/life_tools-install-submit-py --config-dir /tmp/life_tools-install-submit-py/etc
- ./build.sh
- go test ./...
- PYTHONDONTWRITEBYTECODE=1 python3 -m unittest video_subtitle/video_subtitle_test.py
- PYTHONDONTWRITEBYTECODE=1 python3 -m py_compile video_subtitle/video_subtitle.py video_subtitle/video_subtitle_test.py video_subtitle/lib/*.py

Note: go test ./... currently removes renameV1/testData/file_name_with_space.mkv as a test side effect; the file was restored after verification.