### PR TITLE
[codex] fix macos retry_exec install

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -59,7 +59,7 @@
 ./install.sh --tool retry_exec
 ```
 
-脚本会安装 `retry_exec`，并在 `/etc/life_tools/retry_exec.json` 不存在时写入示例配置，还会创建 `/var/log/retry_exec`。安装后编辑配置里的提醒机器人地址和日志路径。
+脚本会安装 `retry_exec`，并在 `/etc/life_tools/retry_exec.json` 不存在时写入示例配置。日志目录按系统选择：Linux 使用 `/var/log/retry_exec`，macOS 使用 `~/Library/Logs/retry_exec`。安装后编辑配置里的提醒机器人地址和日志路径。
 
 
 ![使用照片](https://mcoder-image-storage.oss-cn-hangzhou.aliyuncs.com/image/25261103_2f53b1735abdb443.jpg)

--- a/docs/install.md
+++ b/docs/install.md
@@ -11,7 +11,7 @@
 - 默认安装路径：可执行文件放到 `/usr/local/bin`，Python 工具文件放到 `/usr/local/lib/life_tools`。
 - 默认配置路径：`/etc/life_tools`，可用 `--config-dir` 改变安装脚本写入位置。
 
-写入 `/usr/local`、`/etc/life_tools`、`/var/log` 时可能需要 `sudo`。脚本会在需要时调用 `sudo`，不会覆盖已经存在的配置文件。
+写入 `/usr/local`、`/etc/life_tools` 和 Linux 的 `/var/log` 时可能需要 `sudo`。脚本会在需要时调用 `sudo`，不会覆盖已经存在的配置文件。
 
 ## 工具清单
 
@@ -165,7 +165,9 @@ file_share -h
 
 - Go 工具会先构建到 `output/`，再安装到目标 `bin` 目录。
 - 示例配置只在目标文件不存在时安装，已有配置不会被覆盖。
-- `retry_exec` 会创建 `/var/log/retry_exec` 并设置为当前用户可写。
+- `retry_exec` 的日志目录按系统选择：
+  - Linux：`/var/log/retry_exec`
+  - macOS：`~/Library/Logs/retry_exec`
 - `codex_hook_notify` 的日志目录按系统选择：
   - Linux：`/var/log/codex_hook_notify`
   - macOS：`~/Library/Logs/codex_hook_notify`

--- a/install.sh
+++ b/install.sh
@@ -188,7 +188,7 @@ add_requested_tool() {
     echo "run ./install.sh --help to list supported tools" >&2
     exit 1
   fi
-  if ! contains_tool "$normalized" "${REQUESTED_TOOLS[@]}"; then
+  if [ "${#REQUESTED_TOOLS[@]}" -eq 0 ] || ! contains_tool "$normalized" "${REQUESTED_TOOLS[@]}"; then
     REQUESTED_TOOLS+=("$normalized")
   fi
 }
@@ -202,6 +202,9 @@ add_requested_tools_csv() {
   IFS="$old_ifs"
 
   local name
+  if [ "${#names[@]}" -eq 0 ]; then
+    return
+  fi
   for name in "${names[@]}"; do
     if [ -n "$name" ]; then
       add_requested_tool "$name"
@@ -373,10 +376,50 @@ install_check_keywords() {
   install_config_if_missing "$ROOT_DIR/sample/life_tools/check_keywords.json" "$CONFIG_DIR/check_keywords.json"
 }
 
+retry_exec_log_dir() {
+  case "$OS_NAME" in
+    Darwin)
+      echo "$HOME/Library/Logs/retry_exec"
+      ;;
+    *)
+      echo "/var/log/retry_exec"
+      ;;
+  esac
+}
+
+install_retry_exec_config_if_missing() {
+  local sample="$ROOT_DIR/sample/life_tools/retry_exec.json"
+  local dest="$CONFIG_DIR/retry_exec.json"
+  local log_dir="$1"
+  local tmp_config
+
+  ensure_dir "$CONFIG_DIR" 0755
+  if [ -f "$dest" ]; then
+    echo "config exists, skip overwrite: $dest"
+    if [ "$OS_NAME" = "Darwin" ] && grep -q '"log"[[:space:]]*:[[:space:]]*"/var/log/retry_exec"' "$dest" 2>/dev/null; then
+      echo "warning: $dest still uses /var/log/retry_exec; edit log to $log_dir to avoid sudo-only logging on macOS" >&2
+    fi
+    return
+  fi
+
+  if [ "$log_dir" = "/var/log/retry_exec" ]; then
+    install_file "$sample" "$dest" 0644
+  else
+    mkdir -p "$OUTPUT_DIR"
+    tmp_config="$OUTPUT_DIR/retry_exec.json"
+    sed "s#\"log\": \"/var/log/retry_exec\"#\"log\": \"$log_dir\"#" "$sample" > "$tmp_config"
+    install_file "$tmp_config" "$dest" 0644
+  fi
+  echo "installed sample config: $dest"
+}
+
 install_retry_exec() {
+  local log_dir
+
+  log_dir="$(retry_exec_log_dir)"
   install_go_tool retry_exec retry_exec ./retry_exec/...
-  install_config_if_missing "$ROOT_DIR/sample/life_tools/retry_exec.json" "$CONFIG_DIR/retry_exec.json"
-  ensure_user_writable_dir "/var/log/retry_exec"
+  install_retry_exec_config_if_missing "$log_dir"
+  ensure_user_writable_dir "$log_dir"
 }
 
 install_codex_hook_notify() {


### PR DESCRIPTION
## Summary

- Fix `install.sh --tool retry_exec` on macOS Bash 3.2 when `set -u` sees empty arrays.
- Use `~/Library/Logs/retry_exec` for new macOS `retry_exec` installs while preserving `/var/log/retry_exec` on Linux.
- Update README and install docs to match the OS-specific log directory behavior.

## Root Cause

macOS ships Bash 3.2, where expanding an empty array under `set -u` can fail with `unbound variable`. The retry_exec installer also hard-coded `/var/log/retry_exec`, which forces sudo-only logging on macOS.

## Validation

- `bash -n install.sh`
- Temporary macOS-style install with isolated `HOME`, `--prefix`, and `--config-dir`
- Real install: `./install.sh --tool retry_exec`
- `command -v retry_exec`
- `retry_exec --help`
